### PR TITLE
Fix unexpected argument autodetection_retry

### DIFF
--- a/sqlserver.chart.py
+++ b/sqlserver.chart.py
@@ -353,15 +353,12 @@ class Service(SimpleService):
 
     def _connect(self):
         params = dict(
-            server='localhost',
-            port=1433,
-            user='netdata',
-            password=None,
-            appname='netdata monitoring'
-            )
-        params.update(self.configuration)
-        params.pop('autodetection_retry', None)
-
+            server=self.configuration.get('server', 'localhost'),
+            port=self.configuration.get('port', 1433),
+            user=self.configuration.get('user', 'netdata'),
+            password=self.configuration.get('password', None),
+            appname=self.configuration.get('appname', 'netdata monitoring')
+        )
         if not self.connection:
             try:
                 self.connection = pymssql.connect(**params)

--- a/sqlserver.chart.py
+++ b/sqlserver.chart.py
@@ -360,6 +360,7 @@ class Service(SimpleService):
             appname='netdata monitoring'
             )
         params.update(self.configuration)
+        params.pop('autodetection_retry', None)
 
         if not self.connection:
             try:


### PR DESCRIPTION
Solves the following failure on startup:
```
python.d WARNING: plugin[main] : sqlserver[job_name] : unhandled exception on check : TypeError("connect(
) got an unexpected keyword argument 'autodetection_retry'",), skipping the job
```

Since we are updating `params` with `self.configuration` before calling `pymssql.connect(**params)`, we are adding `autodetection_retry` as an extraneous keyword argument. This causes an unhandled exception, preventing startup.